### PR TITLE
Fixing an error that came up when running benchmark script

### DIFF
--- a/src/Command/Benchmark.php
+++ b/src/Command/Benchmark.php
@@ -26,7 +26,7 @@ class Benchmark extends Command
     protected function execute(InputInterface $input, OutputInterface $output): void
     {
         $file       = $input->getArgument('file');
-        $iterations = $input->getOption('iterations');
+        $iterations = (int) $input->getOption('iterations');
 
         $parserHelper = $this->getHelper('parsers');
 


### PR DESCRIPTION
Seems that sometimes the iterations var can be a string (I noticed this when testing #6) and the Symfony progress bar requires that it's an int.  This didn't happen in `master` branch.

Command ran: `./bin/console benchmark --iterations=2 ../useragent-parser-comparison/files/openwave.txt`

Error thrown:

>PHP Fatal error:  Uncaught TypeError: Argument 2 passed to Symfony\Component\Console\Helper\ProgressBar::__construct() must be of the type integer, string given, called in /Users/jasonklehr/Sites/useragent-parser-comparison-mimmi20/src/Command/Benchmark.php on line 47 and defined in /Users/jasonklehr/Sites/useragent-parser-comparison-mimmi20/vendor/symfony/console/Helper/ProgressBar.php:53

Same command after fix works as expected.

Ah, this does happen in `master` after a `composer update`. Seems that updated Symfony Console causes the error.